### PR TITLE
igraph dependency now optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 
 install:
   - pip install -r requirements.txt
+  - pip install -r requirements_optional.txt
   - pip install codecov pytest-cov
   - pip install .
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README_pypi.md
 include requirements.txt
+include requirements_optional.txt

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ The package offers plotting functions for visualising the results. Again, those 
 ### Notes
 Gaussian Processes regression uses normalised coordinates within the bounds [0, 1]. All normalisation and de-normalisation is done automatically, however when you want to call `predict_y` on GPR model, do not forget to pass normalised coordinates. The normalisation is handled by `sklearn.MinMaxScaler` and `ParameterSpace` instance offers a convenience functions for this: `ParameterSpace.normalise_coords(orig_coords)` and `ParameterSpace.denormalise_coords(normed_coords)`.
 
+Plotting of the ternary tree (`gpso.plotting.plot_ternary_tree()`) requires `igraph` package, whose layout function is exploited. If you want to see the resulting beautiful tree, please install `python-igraph`.
+ 
 ## Known bugs and future improvements
 * currently cannot be installed through `pip` from PyPI, since `GPFlow` 2.0 is not on PyPI yet
 * saving and resuming of the optimisation

--- a/gpso/plotting.py
+++ b/gpso/plotting.py
@@ -6,7 +6,6 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 from anytree import PreOrderIter
-from igraph import Graph
 from scipy.stats import gaussian_kde
 from sklearn.preprocessing import MinMaxScaler
 
@@ -53,6 +52,8 @@ def plot_ternary_tree(
     :type fname: str|None
     :*kwargs: keyword arguments for `plt.figure()`
     """
+    from igraph import Graph
+
     assert isinstance(param_space, ParameterSpace)
     leaves_preorder = list(PreOrderIter(param_space))
     # assign indexes in pre-order order to nodes

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ pathos
 scipy
 scikit-learn
 matplotlib
-python-igraph
 flake8
 pytest
 black

--- a/requirements_optional.txt
+++ b/requirements_optional.txt
@@ -1,0 +1,1 @@
+python-igraph  # plotting-extras 

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,16 @@ for requirement in requirements:
         requirement = f"{pkg_name.lower()} @ " + requirement
     checked_requirements.append(requirement)
 
+extra_requirements = {}
+with open("requirements_optional.txt") as f:
+    extra_reqs = f.read().splitlines()
+for req in extra_reqs:
+    pkg, feature = req.split("#")
+    extra_requirements[feature.strip()] = [pkg.strip()]
+
 setuptools.setup(
     name="pygpso",
-    version="0.2",
+    version="0.3",
     description="Bayesian optimisation method leveraging Gaussian Processes "
     "surrogate",
     long_description=long_description,
@@ -41,5 +48,6 @@ setuptools.setup(
     ],
     python_requires=">=3.6",
     install_requires=checked_requirements,
+    extras_require=extra_requirements,
     include_package_data=True,
 )

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -7,12 +7,12 @@ import unittest
 from shutil import rmtree
 
 import numpy as np
+import pytest
 from gpso.optimisation import GPSOptimiser
 from gpso.param_space import ParameterSpace
 from gpso.plotting import (
     plot_conditional_surrogate_distributions,
     plot_parameter_marginal_distributions,
-    plot_ternary_tree,
 )
 
 
@@ -78,6 +78,10 @@ class TestPlotting(unittest.TestCase):
         rmtree(cls.TEMP_FOLDER)
 
     def test_plot_ternary_tree(self):
+        _ = pytest.importorskip("igraph")
+
+        from gpso.plotting import plot_ternary_tree
+
         FILENAME = os.path.join(self.TEMP_FOLDER, "tree.png")
         plot_ternary_tree(
             self.opt_done.param_space, fname=FILENAME,


### PR DESCRIPTION
- divide requirements to optional and basic
- add notes to README
- import `igraph `within plotting function (lazy import) instead of a global one
- when `igraph` not installed, skip ternary tree plotting test
- bump version to 0.3