### PR TITLE
Hacky saving of GPR model

### DIFF
--- a/gpso/callbacks.py
+++ b/gpso/callbacks.py
@@ -122,9 +122,7 @@ class PreFinaliseSave(GPSOCallback):
         optimiser.param_space.save(
             os.path.join(self.path, f"parameter_space{PKL_EXT}")
         )
-        optimiser.gp_surr.points.save(
-            os.path.join(self.path, f"list_of_points{JSON_EXT}")
-        )
+        optimiser.gp_surr.save(self.path)
 
 
 class GPFlowCheckpoints(GPSOCallback):

--- a/gpso/utils.py
+++ b/gpso/utils.py
@@ -4,12 +4,26 @@ Useful utilities.
 
 import json
 import logging
+import os
 
 LOG_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
 LOG_EXT = ".log"
 JSON_EXT = ".json"
 PKL_EXT = ".pkl"
 H5_EXT = ".h5"
+
+
+def make_dirs(path):
+    """
+    Create directory.
+
+    :param path: path for new directory
+    :type path: str
+    """
+    try:
+        os.makedirs(path)
+    except OSError as error:
+        logging.warning(f"{path} could not be created: {error}")
 
 
 def load_json(filename):

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -53,7 +53,9 @@ class TestCallbacks(unittest.TestCase):
     ]
     LOG_FILENAME = f"log{LOG_EXT}"
     PARAM_SPACE_FILENAME = f"parameter_space{PKL_EXT}"
-    LIST_OF_POINTS_FILRNAME = f"list_of_points{JSON_EXT}"
+    LIST_OF_POINTS_FILRNAME = f"points{JSON_EXT}"
+    GPR_MODEL_FILENAME = f"GPRmodel{PKL_EXT}"
+    GPR_INFO_FILENAME = f"GPRinfo{JSON_EXT}"
 
     @staticmethod
     def _obj_func(point):
@@ -110,6 +112,11 @@ class TestCallbacks(unittest.TestCase):
         """
         rmtree(TEMP_FOLDER)
 
+    def _check_file_exists_and_remove(self, filename):
+        file_ = os.path.join(TEMP_FOLDER, filename)
+        self.assertTrue(os.path.exists(file_))
+        os.remove(file_)
+
     def test_callback(self):
         # first test logging callback
         log = os.path.join(TEMP_FOLDER, self.LOG_FILENAME)
@@ -118,12 +125,10 @@ class TestCallbacks(unittest.TestCase):
         os.remove(log)
 
         # now test pre-finalise saving
-        param_space = os.path.join(TEMP_FOLDER, self.PARAM_SPACE_FILENAME)
-        self.assertTrue(os.path.exists(param_space))
-        os.remove(param_space)
-        list_of_points = os.path.join(TEMP_FOLDER, self.LIST_OF_POINTS_FILRNAME)
-        self.assertTrue(os.path.exists(list_of_points))
-        os.remove(list_of_points)
+        self._check_file_exists_and_remove(self.PARAM_SPACE_FILENAME)
+        self._check_file_exists_and_remove(self.LIST_OF_POINTS_FILRNAME)
+        self._check_file_exists_and_remove(self.GPR_MODEL_FILENAME)
+        self._check_file_exists_and_remove(self.GPR_INFO_FILENAME)
 
         # test checkpoints
         self.assertTrue(

--- a/tests/test_gp_surrogate.py
+++ b/tests/test_gp_surrogate.py
@@ -9,7 +9,6 @@ from shutil import rmtree
 
 import gpflow
 import numpy as np
-import pytest
 from gpso.gp_surrogate import (
     DUPLICATE_TOLERANCE,
     GPListOfPoints,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,8 +42,6 @@ class TestUtils(unittest.TestCase):
 
         self.assertDictEqual(load_json(filename), self.TEST_DICT)
 
-    LOGGER = logging.getLogger(__name__)
-
     def test_make_dirs(self):
         # make new dir
         make_dirs(os.path.join(self.TEMP_FOLDER, "new_test_dir"))


### PR DESCRIPTION
* for now until proper saving in GPFlow 2.0 is resolved
* now hacky way with saving parameters as dict into pickle and name of kernel and mean function to `json`
* pre-finalise callback now saves full `GPSurrogate`

with this, it should be possible to resume optimisation from saved state